### PR TITLE
Implement command interpretation API service

### DIFF
--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,0 +1,21 @@
+import type { ApiResponse, CommandInterpretation } from "../types";
+
+const BASE_URL = "http://localhost:8000"; // Adjust as necessary
+
+export const interpretCommand = async (
+  command: string
+): Promise<ApiResponse<CommandInterpretation>> => {
+  const response = await fetch(`${BASE_URL}/interpret`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ command }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`HTTP error! status: ${response.status}`);
+  }
+
+  return response.json();
+};


### PR DESCRIPTION
This pull request introduces a new API service to the frontend for interpreting commands. The main change is the addition of the `interpretCommand` function, which sends a command to a backend endpoint and returns the interpreted result.

API integration:

* Added a new `interpretCommand` function in `frontend/src/services/api.ts` to send POST requests to the `/interpret` endpoint and handle responses for command interpretation.